### PR TITLE
[BUG FIX] Fixed openmp monte carlo bug.

### DIFF
--- a/threaded_mc/omp_mc.c
+++ b/threaded_mc/omp_mc.c
@@ -49,8 +49,9 @@ int main(int argc, char** argv)
     long seed;
     int nthreads;
     srandom(clock());
-    process_args(argc, argv, &param);
+    nthreads = process_args(argc, argv, &param);
     mc_result_init(&result);
+    omp_set_num_threads(nthreads);
 
     t1 = omp_get_wtime();
     #pragma omp parallel shared(result, param, nthreads) private(seed)


### PR DESCRIPTION
`omp_mc.c` was ignoring the `-p` flag and instead was always using 2
threads. This commit makes it so that openmp uses the number of threads
specified by the `-p` flag.
